### PR TITLE
[fix]: Solve the bug that balance formatting does not support decimals

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -28,8 +28,7 @@ export const isValidAddress = (address: string): boolean => {
  * @returns {BN} The converted BN value.
  */
 export const formatNumberToBalance = (value: number, decimals?: number): BN => {
-  const multiplier = new BN(10).pow(new BN(decimals || 18))
-  return new BN(value).mul(multiplier)
+  return new BN(BigInt(value * Math.pow(10,decimals || 18));
 }
 
 /**


### PR DESCRIPTION
### Current issues:

1. The bn.js library does not support decimals.
2. When new bn (any decimal) the result will return 0.

### Solution:
1. First enlarge the decimal by 10^18, which must be an integer, then store it into the BigInt type, and finally convert the BigInt to Bn.
2. This solution has the problem of insufficient precision. The subtle difference may be better than not being able to use decimals.
3. If you want to completely solve this problem, you must introduce some high-precision mathematical code libraries that support extremely large numbers.