### PR TITLE
fix: correct negative decimal conversion in formatNumberToBalance

### DIFF
--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -1,0 +1,11 @@
+import { formatNumberToBalance } from "./utils"
+
+describe("formatNumberToBalance", () => {
+  it("converts positive decimals to base units", () => {
+    expect(formatNumberToBalance(1.5, 2).toString()).toBe("150")
+  })
+
+  it("converts negative decimals to base units", () => {
+    expect(formatNumberToBalance(-1.5, 2).toString()).toBe("-150")
+  })
+})

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -100,5 +100,5 @@ export const formatNumberToBalance = (value: number | string, decimals: number =
   const integerBN = new BN(integerPart).mul(new BN(10).pow(new BN(decimals)))
   if (!fractionalPart) return integerBN
   const fractionalBN = new BN(`${fractionalPart}${"0".repeat(decimals)}`.slice(0, decimals))
-  return integerBN.add(fractionalBN)
+  return integerPart.startsWith("-") ? integerBN.sub(fractionalBN) : integerBN.add(fractionalBN)
 }


### PR DESCRIPTION
Closes #11

This change fixes negative decimal conversion in `formatNumberToBalance` and adds a regression test.

| Step | Before fix | After fix |
|---|---|---|
| Reproduction command | `npx ts-node -e "import { formatNumberToBalance } from './src/core/utils'; console.log(formatNumberToBalance(-1.5, 2).toString())"` | same command |
| Key output | `-50` | `-150` |
| Test result | `npm test` failed because no tests existed, and the bug reproduction showed wrong output | `npm test` passes with new regression test (`2 passed`) |

## Short test notes
- Added `src/core/utils.test.ts` with positive and negative decimal cases.
- Confirmed `npm run start` still succeeds.
